### PR TITLE
Added decimal support. Fixed test cases when run on Sunday.

### DIFF
--- a/src/Chronic.Tests/CustomParsingTest.cs
+++ b/src/Chronic.Tests/CustomParsingTest.cs
@@ -32,7 +32,17 @@ namespace Chronic.Tests
 				.AssertEquals(Time.New(2006, 8, 23, 14));
 		}
 
-        [Fact]
+		[Fact]
+		public void _in_7_hours_from_now() {
+			Parse("in 7 hours from now")
+				.AssertEquals(Now().AddHours(7));
+		}
+		[Fact]
+		public void _in_7_pt_5_hours_from_now() {
+			Parse("in 7.5 hours from now")
+				.AssertEquals(Now().AddHours(7.5));
+		}
+		[Fact]
         public void _in_7_days_from_dotdotdot()
         {
             Parse("in 7 days from").AssertEquals(Time.New(2006, 8, 23, 14));

--- a/src/Chronic.Tests/Parsing/BasicExpressionsTests.cs
+++ b/src/Chronic.Tests/Parsing/BasicExpressionsTests.cs
@@ -61,42 +61,42 @@ namespace Chronic.Tests.Parsing
         [Fact]
         public void next_week_is_parsed_correctly()
         {
-            Parse("next week").AssertStartsAt(GetNextWeekday(DateTime.Today, DayOfWeek.Sunday));
+            Parse("next week").AssertStartsAt(NextWeek(DateTime.Today));
         }
         [Fact]
         public void week_after_next_week_is_parsed_correctly()
         {
-            Parse("week after next week").AssertStartsAt( GetNextWeekday(DateTime.Today, DayOfWeek.Sunday).AddDays(7));
+			Parse("week after next week").AssertStartsAt(NextWeek(DateTime.Today).AddDays(7));
         }
         [Fact]
         public void week_after_next_is_parsed_correctly()
         {
-            Parse("week after next").AssertStartsAt(GetNextWeekday(DateTime.Today, DayOfWeek.Sunday).AddDays(7));
+			Parse("week after next").AssertStartsAt(NextWeek(DateTime.Today).AddDays(7));
         }
         [Fact]
         public void week_after_next_day_is_parsed_correctly()
         {
-            Parse("week after next day").AssertStartsAt(GetNextWeekday(DateTime.Today, DateTime.Today.DayOfWeek).AddDays(1).AddDays(7));
+            Parse("week after next day").AssertStartsAt(GetFirstDateOfWeekday(DateTime.Today, DateTime.Today.DayOfWeek).AddDays(1).AddDays(7));
         }
 
         [Fact]
         public void week_after_friday_is_parsed_correctly()
         {
-            Parse("week after friday").AssertStartsAt(GetNextWeekday(DateTime.Today, DayOfWeek.Friday).AddDays( 7));
+            Parse("week after friday").AssertStartsAt(GetFirstDateOfWeekday(DateTime.Today, DayOfWeek.Friday).AddDays( 7));
         }
 
         [Fact]
         public void week_after_next_friday_is_parsed_correctly()
         {
-            Parse("week after next friday").AssertStartsAt(GetNextWeekday(DateTime.Today, DayOfWeek.Friday).AddDays(2*7));
+            Parse("week after next friday").AssertStartsAt(GetFirstDateOfWeekday(DateTime.Today, DayOfWeek.Friday).AddDays(2*7));
         }
-
-        public static DateTime GetNextWeekday(DateTime start, DayOfWeek day)
+		public static DateTime NextWeek(DateTime start) {
+			return GetFirstDateOfWeekday(start.DayOfWeek == DayOfWeek.Sunday ? start.AddDays(1) : start, DayOfWeek.Sunday);
+		}
+        public static DateTime GetFirstDateOfWeekday(DateTime start, DayOfWeek day)
         {
             // The (... + 7) % 7 ensures we end up with a value in the range [0, 6]
             int daysToAdd = ((int)day - (int)start.DayOfWeek + 7) % 7;
-			if (daysToAdd == 0)
-				daysToAdd = 7;
 
 			return start.AddDays(daysToAdd);
         }
@@ -110,10 +110,10 @@ namespace Chronic.Tests.Parsing
 		[Fact]
 		public void next_friday_or_weekend_is_parsed_correctly()
 		{
-			Parse("next friday").AssertStartsAt(GetNextWeekday(DateTime.Today, DayOfWeek.Friday).AddDays(7));
-			Parse("next week friday").AssertStartsAt(GetNextWeekday(DateTime.Today, DayOfWeek.Friday).AddDays(7));
-			Parse("next weekend").AssertStartsAt(GetNextWeekday(DateTime.Today, DayOfWeek.Saturday).AddDays(7));
-			Parse("next week weekend").AssertStartsAt(GetNextWeekday(DateTime.Today, DayOfWeek.Saturday).AddDays(7));
+			Parse("next friday").AssertStartsAt(GetFirstDateOfWeekday(DateTime.Today, DayOfWeek.Friday).AddDays(7));
+			Parse("next week friday").AssertStartsAt(GetFirstDateOfWeekday(DateTime.Today, DayOfWeek.Friday).AddDays(7));
+			Parse("next weekend").AssertStartsAt(GetFirstDateOfWeekday(DateTime.Today, DayOfWeek.Saturday).AddDays(7));
+			Parse("next week weekend").AssertStartsAt(GetFirstDateOfWeekday(DateTime.Today, DayOfWeek.Saturday).AddDays(7));
 		}
     }
 }

--- a/src/Chronic.Tests/Parsing/BasicExpressionsTests.cs
+++ b/src/Chronic.Tests/Parsing/BasicExpressionsTests.cs
@@ -95,7 +95,10 @@ namespace Chronic.Tests.Parsing
         {
             // The (... + 7) % 7 ensures we end up with a value in the range [0, 6]
             int daysToAdd = ((int)day - (int)start.DayOfWeek + 7) % 7;
-            return start.AddDays(daysToAdd);
+			if (daysToAdd == 0)
+				daysToAdd = 7;
+
+			return start.AddDays(daysToAdd);
         }
 
 		[Fact]

--- a/src/Chronic.Tests/Parsing/KnownPatternsParsingTests.cs
+++ b/src/Chronic.Tests/Parsing/KnownPatternsParsingTests.cs
@@ -43,8 +43,8 @@ namespace Chronic.Tests.Parsing
             Parse("may 28 at 5pm", new { Context = Pointer.Type.Past })
                 .AssertEquals(Time.New(2006, 5, 28, 17));
 
-            Parse("may 28 at 5:32.19pm", new { Context = Pointer.Type.Past })
-                .AssertEquals(Time.New(2006, 5, 28, 17, 32, 19));
+            Parse("may 28 at 5:32.5pm", new { Context = Pointer.Type.Past })
+                .AssertEquals(Time.New(2006, 5, 28, 17, 32, 30));
         }
 
         [Fact]
@@ -309,7 +309,7 @@ namespace Chronic.Tests.Parsing
                 .AssertEquals(Time.New(2006, 8, 20, 15, 30, 30));
 
             Parse("2006-08-20 15:30.30")
-                .AssertEquals(Time.New(2006, 8, 20, 15, 30, 30));
+                .AssertEquals(Time.New(2006, 8, 20, 15, 30, 18));
 
             Parse("1902-08-20")
                 .AssertEquals(Time.New(1902, 8, 20, 12, 0, 0));

--- a/src/Chronic/Handlers/OdRmnSyHandler.cs
+++ b/src/Chronic/Handlers/OdRmnSyHandler.cs
@@ -13,14 +13,14 @@ namespace Chronic.Handlers
             var month = (int) tokens[1].GetTag<RepeaterMonthName>().Value;
             var year = tokens[2].GetTag<ScalarYear>().Value;
             var timeTokens = tokens.Skip(3).ToList();
-            if (Time.IsMonthOverflow(year, month, day))
+            if (Time.IsMonthOverflow((int)year, month, day))
             {
                 return null;
             }
 
             try
             {
-                var dayStart = Time.New(year, month, day);
+                var dayStart = Time.New((int)year, month, day);
                 return Utils.DayOrTime(dayStart, timeTokens, options);
             }
             catch (ArgumentException)

--- a/src/Chronic/Handlers/RHandler.cs
+++ b/src/Chronic/Handlers/RHandler.cs
@@ -10,7 +10,7 @@ namespace Chronic.Handlers
         {
             if (tokens.Count == 1 && tokens[0].IsTaggedAs<ScalarDay>())
             {
-                var day = tokens[0].GetTag<ScalarDay>().Value;
+                var day = (int)tokens[0].GetTag<ScalarDay>().Value;
                 if (Time.IsMonthOverflow(options.Clock().Year, options.Clock().Month, day))
                 {
                     return null;

--- a/src/Chronic/Handlers/RdnRmnSdHandler.cs
+++ b/src/Chronic/Handlers/RdnRmnSdHandler.cs
@@ -12,13 +12,13 @@ namespace Chronic.Handlers
             var day = tokens[2].GetTag<ScalarDay>().Value;
             var year = options.Clock().Year;
 
-            if (Time.IsMonthOverflow(year, (int) month.Value, day))
+            if (Time.IsMonthOverflow((int)year, (int) month.Value, (int)day))
             {
                 return null;
             }
             try
             {
-                var start = Time.New(year, (int) month.Value, day);
+                var start = Time.New((int)year, (int) month.Value, (int)day);
                 var end = start.AddDays(1);
                 return new Span(start, end);
             }

--- a/src/Chronic/Handlers/RdnSdRmnHandler.cs
+++ b/src/Chronic/Handlers/RdnSdRmnHandler.cs
@@ -9,7 +9,7 @@ namespace Chronic.Handlers
 		public Span Handle(IList<Token> tokens, Options options)
 		{
 			var month = tokens[2].GetTag<RepeaterMonthName>();
-			var day = tokens[1].GetTag<ScalarDay>().Value;
+			var day = (int)tokens[1].GetTag<ScalarDay>().Value;
 			var year = options.Clock().Year;
 
 			if (Time.IsMonthOverflow(year, (int)month.Value, day))

--- a/src/Chronic/Handlers/RmnOdSyHandler.cs
+++ b/src/Chronic/Handlers/RmnOdSyHandler.cs
@@ -14,13 +14,13 @@ namespace Chronic.Handlers
             var year = tokens[2].GetTag<ScalarYear>().Value;
       
             var time_tokens = tokens.Skip(3).ToList();
-            if (Time.IsMonthOverflow(year, month, day))
+            if (Time.IsMonthOverflow((int)year, month, day))
             {
                 return null;
             }
             try
             {
-                var dayStart = Time.New(year, month, day);
+                var dayStart = Time.New((int)year, month, day);
                 return Utils.DayOrTime(dayStart, time_tokens, options);
             }
             catch (ArgumentException)

--- a/src/Chronic/Handlers/RmnOnOdHandler.cs
+++ b/src/Chronic/Handlers/RmnOnOdHandler.cs
@@ -11,7 +11,7 @@ namespace Chronic.Handlers
         public Span Handle(IList<Token> tokens, Options options)
         {
             var month = tokens[0].GetTag<RepeaterMonthName>();
-            var day = tokens[1].GetTag<ScalarDay>().Value;
+            var day = (int)tokens[1].GetTag<ScalarDay>().Value;
             var now = options.Clock();
 
             if (Time.IsMonthOverflow(now.Year, (int)month.Value, day))

--- a/src/Chronic/Handlers/RmnSdOnHandler.cs
+++ b/src/Chronic/Handlers/RmnSdOnHandler.cs
@@ -15,13 +15,13 @@ namespace Chronic.Handlers
             if (tokens.Count > 3)
             {
                 month = tokens[2].GetTag<RepeaterMonthName>();
-                day = tokens[3].GetTag<ScalarDay>().Value;
+                day = (int)tokens[3].GetTag<ScalarDay>().Value;
                 remainingTokens = tokens.Take(2).ToList();
             }
             else
             {
                 month = tokens[1].GetTag<RepeaterMonthName>();
-                day = tokens[2].GetTag<ScalarDay>().Value;
+                day = (int)tokens[2].GetTag<ScalarDay>().Value;
                 remainingTokens = tokens.Take(1).ToList();                
             }
 

--- a/src/Chronic/Handlers/RmnSdSyHandler.cs
+++ b/src/Chronic/Handlers/RmnSdSyHandler.cs
@@ -19,7 +19,7 @@ namespace Chronic.Handlers
             try
             {
                 var timeTokens = tokens.Skip(3).ToList();
-                var dayStart = Time.New(year, month, day);
+                var dayStart = Time.New((int)year, month, (int)day);
                 span = Utils.DayOrTime(dayStart, timeTokens, options);
             }
             catch (ArgumentException)

--- a/src/Chronic/Handlers/SRPHandler.cs
+++ b/src/Chronic/Handlers/SRPHandler.cs
@@ -13,7 +13,7 @@ namespace Chronic.Handlers
 
         public Span Handle(IList<Token> tokens, Span span, Options options)
         {
-            int distance = 1;
+            decimal distance = 1;
             int index = 0;
 
             if (tokens[0].GetTag<Scalar>() != null)

--- a/src/Chronic/Handlers/SdRmnHandler.cs
+++ b/src/Chronic/Handlers/SdRmnHandler.cs
@@ -10,7 +10,7 @@ namespace Chronic.Handlers
         public Span Handle(IList<Token> tokens, Options options)
         {
             var month = tokens[1].GetTag<RepeaterMonthName>();
-            var day = tokens[0].GetTag<ScalarDay>().Value;
+            var day = (int)tokens[0].GetTag<ScalarDay>().Value;
             if (Time.IsMonthOverflow(options.Clock().Year, (int)month.Value, day))
             {
                 return null;

--- a/src/Chronic/Handlers/SdSmSyHandler.cs
+++ b/src/Chronic/Handlers/SdSmSyHandler.cs
@@ -9,9 +9,9 @@ namespace Chronic.Handlers
     {
         public Span Handle(IList<Token> tokens, Options options)
         {
-            var month = tokens[1].GetTag<ScalarMonth>().Value;
-            var day = tokens[0].GetTag<ScalarDay>().Value;
-            var year = tokens[2].GetTag<ScalarYear>().Value;
+            var month =(int) tokens[1].GetTag<ScalarMonth>().Value;
+            var day = (int)tokens[0].GetTag<ScalarDay>().Value;
+            var year = (int)tokens[2].GetTag<ScalarYear>().Value;
             var timeTokens = tokens.Skip(3).ToList();
 
             if (Time.IsMonthOverflow(year, month, day))

--- a/src/Chronic/Handlers/SmSdSyHandler.cs
+++ b/src/Chronic/Handlers/SmSdSyHandler.cs
@@ -10,8 +10,8 @@ namespace Chronic.Handlers
         public virtual Span Handle(IList<Token> tokens, Options options)
         {
             var month = (int)tokens[0].GetTag<ScalarMonth>().Value;
-            var day = tokens[1].GetTag<ScalarDay>().Value;
-            var year = tokens[2].GetTag<ScalarYear>().Value;
+            var day = (int)tokens[1].GetTag<ScalarDay>().Value;
+            var year = (int)tokens[2].GetTag<ScalarYear>().Value;
 
             var time_tokens = tokens.Skip(3).ToList();
             if (Time.IsMonthOverflow(year, month, day))

--- a/src/Chronic/Handlers/SmSyHandler.cs
+++ b/src/Chronic/Handlers/SmSyHandler.cs
@@ -8,7 +8,7 @@ namespace Chronic.Handlers
         public Span Handle(IList<Token> tokens, Options options)
         {
             var month = (int)tokens[0].GetTag<ScalarMonth>().Value;
-            var year = tokens[1].GetTag<ScalarYear>().Value;
+            var year = (int)tokens[1].GetTag<ScalarYear>().Value;
 
             try
             {

--- a/src/Chronic/Handlers/SyRmnOdHandler.cs
+++ b/src/Chronic/Handlers/SyRmnOdHandler.cs
@@ -10,17 +10,17 @@ namespace Chronic.Handlers
     {
         public Span Handle(IList<Token> tokens, Options options)
         {
-            var year = tokens[0].GetTag<ScalarYear>().Value;
-            var month = tokens[1].GetTag<RepeaterMonthName>();
-            var day = tokens[2].GetTag<OrdinalDay>().Value;
+            var year = (int)tokens[0].GetTag<ScalarYear>().Value;
+            var month = (int)tokens[1].GetTag<RepeaterMonthName>().Value;
+            var day = (int)tokens[2].GetTag<OrdinalDay>().Value;
             var time_tokens = tokens.Skip(3).ToList();
-            if (Time.IsMonthOverflow(year, (int)month.Value, day))
+            if (Time.IsMonthOverflow(year, month, day))
             {
                 return null;
             }
             try
             {
-                var dayStart = Time.New(year, (int)month.Value, day);
+                var dayStart = Time.New(year, month, day);
                 return Utils.DayOrTime(dayStart, time_tokens, options);
 
             }

--- a/src/Chronic/Handlers/Utils.cs
+++ b/src/Chronic/Handlers/Utils.cs
@@ -16,7 +16,7 @@ namespace Chronic.Handlers
             else
                 repeater.Now = outerSpan.Start.Value.AddSeconds(-1);
 
-			int ordinal = 1;
+			var ordinal = 1.0m;
 			if (tokens[0].GetTag<Ordinal>() != null)
 				ordinal= tokens[0].GetTag<Ordinal>().Value;
 			else

--- a/src/Chronic/Tags/Repeaters/Repeater.cs
+++ b/src/Chronic/Tags/Repeaters/Repeater.cs
@@ -37,7 +37,7 @@ namespace Chronic.Tags.Repeaters
 
         protected abstract Span CurrentSpan(Pointer.Type pointer);
 
-        public abstract Span GetOffset(Span span, int amount, Pointer.Type pointer);
+        public abstract Span GetOffset(Span span, decimal amount, Pointer.Type pointer);
 
         public override string ToString()
         {

--- a/src/Chronic/Tags/Repeaters/RepeaterDay.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterDay.cs
@@ -56,10 +56,10 @@ namespace Chronic.Tags.Repeaters
         }
 
 
-        public override Span GetOffset(Span span, int amount, Pointer.Type pointer)
+        public override Span GetOffset(Span span, decimal amount, Pointer.Type pointer)
         {
             var direction = (int)pointer;
-            return span.Add(direction * amount * RepeaterDay.DAY_SECONDS);
+            return span.Add((long)(direction * amount * RepeaterDay.DAY_SECONDS));
         }
 
         public override int GetWidth()

--- a/src/Chronic/Tags/Repeaters/RepeaterDayName.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterDayName.cs
@@ -66,7 +66,7 @@ namespace Chronic.Tags.Repeaters
             return base.GetNextSpan(pointer);
         }
 
-        public override Span GetOffset(Span span, int amount, Pointer.Type pointer)
+        public override Span GetOffset(Span span, decimal amount, Pointer.Type pointer)
         {
             throw new System.NotImplementedException();
         }

--- a/src/Chronic/Tags/Repeaters/RepeaterDayPortion.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterDayPortion.cs
@@ -105,12 +105,12 @@ namespace Chronic.Tags.Repeaters
         }
 
 
-        public override Span GetOffset(Span span, int amount, Pointer.Type pointer)
+        public override Span GetOffset(Span span, decimal amount, Pointer.Type pointer)
         {
             Now = span.Start;
             var portionSpan = NextSpan(pointer);
             var direction = (pointer == Pointer.Type.Future) ? 1 : -1;
-            portionSpan = portionSpan.Add(direction * (amount - 1) * RepeaterDay.DAY_SECONDS);
+            portionSpan = portionSpan.Add((long)(direction * (amount - 1) * RepeaterDay.DAY_SECONDS));
             return portionSpan;
         }
 

--- a/src/Chronic/Tags/Repeaters/RepeaterFortnight.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterFortnight.cs
@@ -24,7 +24,7 @@ namespace Chronic.Tags.Repeaters
             throw new System.NotImplementedException();
         }
 
-        public override Span GetOffset(Span span, int amount, Pointer.Type pointer)
+        public override Span GetOffset(Span span, decimal amount, Pointer.Type pointer)
         {
             throw new System.NotImplementedException();
         }

--- a/src/Chronic/Tags/Repeaters/RepeaterHour.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterHour.cs
@@ -80,10 +80,10 @@ namespace Chronic.Tags.Repeaters
             return new Span(hourStart, hourEnd);
         }
 
-        public override Span GetOffset(Span span, int amount, Pointer.Type pointer)
+        public override Span GetOffset(Span span, decimal amount, Pointer.Type pointer)
         {
             var direction = (pointer == Pointer.Type.Future) ? 1 : -1;
-            return span.Add(direction * amount * RepeaterHour.HOUR_SECONDS);
+            return span.Add((long)(direction * amount * RepeaterHour.HOUR_SECONDS));
         }
     }
 }

--- a/src/Chronic/Tags/Repeaters/RepeaterMinute.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterMinute.cs
@@ -76,10 +76,10 @@ namespace Chronic.Tags.Repeaters
             return new Span(minuteBegin, minuteEnd);
         }
 
-        public override Span GetOffset(Span span, int amount, Pointer.Type pointer)
+        public override Span GetOffset(Span span, decimal amount, Pointer.Type pointer)
         {
             int direction = (pointer == Pointer.Type.Future) ? 1 : -1;
-            return span.Add(direction * amount * RepeaterMinute.MINUTE_SECONDS);
+            return span.Add((long)(direction * amount * RepeaterMinute.MINUTE_SECONDS));
         }
 
         public override string ToString()

--- a/src/Chronic/Tags/Repeaters/RepeaterMonth.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterMonth.cs
@@ -67,15 +67,24 @@ namespace Chronic.Tags.Repeaters
             }
             return new Span(monthStart, monthEnd);
         }
+		public static DateTime AddMonthsWithFraction(DateTime date, decimal amount)
+		{
+			var day_excess = amount - (int)amount;
+			date = date.AddMonths((int)amount);
 
-        public override Span GetOffset(Span span, int amount, Pointer.Type pointer)
+			date = date.AddDays((double)(Time.DaysInMonth(date.Year, date.Month) * day_excess));
+			return date;
+		}
+
+        public override Span GetOffset(Span span, decimal amount, Pointer.Type pointer)
         {
             int direction = (pointer == Pointer.Type.Future) ? 1 : -1;
-            return new Span(
-                span.Start.Value.AddMonths(amount * direction),
-                span.End.Value.AddMonths(amount * direction)
-            );
+			amount *= direction;
 
+			return  new Span(
+				AddMonthsWithFraction(span.Start.Value,amount),
+				AddMonthsWithFraction(span.End.Value, amount)
+            );
         }
 
 

--- a/src/Chronic/Tags/Repeaters/RepeaterMonthName.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterMonthName.cs
@@ -128,7 +128,7 @@ namespace Chronic.Tags.Repeaters
             return span;
         }
 
-        public override Span GetOffset(Span span, int amount, Pointer.Type pointer)
+        public override Span GetOffset(Span span, decimal amount, Pointer.Type pointer)
         {
             throw new IllegalStateException("Not implemented.");
         }

--- a/src/Chronic/Tags/Repeaters/RepeaterScanner.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterScanner.cs
@@ -124,7 +124,7 @@ namespace Chronic.Tags.Repeaters
         }
 
         static readonly Regex _timePattern =
-            @"^\d{1,2}(:?\d{2})?([\.:]?\d{2})?$".Compile();
+            @"^\d{1,2}(:?\d{2})?([\.:]?\d{1,2})?$".Compile();
 
         static readonly List<dynamic> DayPortionPatterns = new List<dynamic>
             {

--- a/src/Chronic/Tags/Repeaters/RepeaterSeason.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterSeason.cs
@@ -23,7 +23,7 @@ namespace Chronic.Tags.Repeaters
             throw new NotImplementedException();
         }
 
-        public override Span GetOffset(Span span, int amount, Pointer.Type pointer)
+        public override Span GetOffset(Span span, decimal amount, Pointer.Type pointer)
         {
             throw new NotImplementedException();
         }

--- a/src/Chronic/Tags/Repeaters/RepeaterSecond.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterSecond.cs
@@ -36,12 +36,12 @@ namespace Chronic.Tags.Repeaters
             return new Span(now, now.AddSeconds(1));
         }
 
-        public override Span GetOffset(Span span, int amount,
+        public override Span GetOffset(Span span, decimal amount,
                                        Pointer.Type pointer)
         {
             int direction = (pointer == Pointer.Type.Future) ? 1 : -1;
             // WARN: Does not use Calendar
-            return span.Add(direction * amount * RepeaterSecond.SECOND_SECONDS);
+            return span.Add((long)(direction * amount * RepeaterSecond.SECOND_SECONDS));
         }
 
         public override int GetWidth()

--- a/src/Chronic/Tags/Repeaters/RepeaterWeek.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterWeek.cs
@@ -110,10 +110,10 @@ namespace Chronic.Tags.Repeaters
 
         }
 
-        public override Span GetOffset(Span span, int amount, Pointer.Type pointer)
+        public override Span GetOffset(Span span, decimal amount, Pointer.Type pointer)
         {
             var direction = (pointer == Pointer.Type.Future) ? 1 : -1;
-            return span.Add(direction * amount * RepeaterWeek.WEEK_SECONDS);
+            return span.Add((long)(direction * amount * RepeaterWeek.WEEK_SECONDS));
         }
 
         public override string ToString()

--- a/src/Chronic/Tags/Repeaters/RepeaterWeekend.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterWeekend.cs
@@ -80,7 +80,7 @@ namespace Chronic.Tags.Repeaters
 
         }
 
-        public override Span GetOffset(Span span, int amount, Pointer.Type pointer)
+        public override Span GetOffset(Span span, decimal amount, Pointer.Type pointer)
         {
             var direction = (pointer == Pointer.Type.Future) ? 1 : -1;
             var weekend = new RepeaterWeekend();
@@ -88,7 +88,7 @@ namespace Chronic.Tags.Repeaters
             var start = weekend
                 .GetNextSpan(pointer)
                 .Start.Value
-                .AddSeconds((amount - 1) * direction * RepeaterWeek.WEEK_SECONDS);
+                .AddSeconds((double)((amount - 1) * direction * RepeaterWeek.WEEK_SECONDS));
 
             return new Span(start, start.AddSeconds(span.Width));
 

--- a/src/Chronic/Tags/Repeaters/RepeaterYear.cs
+++ b/src/Chronic/Tags/Repeaters/RepeaterYear.cs
@@ -71,7 +71,7 @@ namespace Chronic.Tags.Repeaters
         }
 
 
-        public override Span GetOffset(Span span, int amount, Pointer.Type pointer)
+        public override Span GetOffset(Span span, decimal amount, Pointer.Type pointer)
         {
             var direction = (int)pointer;
             var newBegin = BuildOffsetTime(span.Start.Value, amount, direction);
@@ -79,12 +79,12 @@ namespace Chronic.Tags.Repeaters
             return new Span(newBegin, newEnd);
         }
 
-        private DateTime BuildOffsetTime(DateTime time, int amount, int direction)
+        private DateTime BuildOffsetTime(DateTime time, decimal amount, int direction)
         {
             var year = time.Year + (amount * direction);
-            var days = Time.DaysInMonth(year, time.Month);
+            var days = Time.DaysInMonth((int)year, time.Month);
             var day = time.Day > days ? days : time.Day;
-            return Time.New(year, time.Month, day, time.Hour, time.Minute,
+            return Time.New((int)year, time.Month, day, time.Hour, time.Minute,
                             time.Second);
         }
 

--- a/src/Chronic/Tags/Scalar.cs
+++ b/src/Chronic/Tags/Scalar.cs
@@ -2,9 +2,9 @@ using System.Collections.Generic;
 
 namespace Chronic
 {
-    public class Scalar : Tag<int>
+    public class Scalar : Tag<decimal>
     {
-        public Scalar(int value)
+        public Scalar(decimal value)
             : base(value)
         {
         }
@@ -17,7 +17,7 @@ namespace Chronic
 
     public class ScalarDay : Scalar
     {
-        public ScalarDay(int value)
+        public ScalarDay(decimal value)
             : base(value)
         {
         }
@@ -30,7 +30,7 @@ namespace Chronic
 
     public class ScalarMonth : Scalar
     {
-        public ScalarMonth(int value)
+        public ScalarMonth(decimal value)
             : base(value)
         {
         }
@@ -43,7 +43,7 @@ namespace Chronic
 
     public class ScalarYear : Scalar
     {
-        public ScalarYear(int value)
+        public ScalarYear(decimal value)
             : base(value)
         {
         }

--- a/src/Chronic/Tags/ScalarScanner.cs
+++ b/src/Chronic/Tags/ScalarScanner.cs
@@ -8,16 +8,16 @@ namespace Chronic
     public class ScalarScanner : ITokenScanner
     {
         static readonly Regex _pattern = new Regex(
-            @"^\d*$",
+			@"^\d*([.]\d+)?$",
             RegexOptions.Singleline | RegexOptions.Compiled);
 
         static readonly Regex _dayPattern = new Regex(
-            @"^\d\d?$",
+            @"^\d\d?([.]\d+)?$",
             RegexOptions.Singleline | RegexOptions.Compiled);
 
         static readonly Regex _monthPattern = _dayPattern;
         static readonly Regex _yearPattern = new Regex(
-            @"^([1-9]\d)?\d\d?$",
+			@"^([1-9]\d)?\d\d?([.]\d+)?$",
             RegexOptions.Singleline | RegexOptions.Compiled);
 
         static readonly string[] _dayPeriods = new string[] { "am", "pm", "morning", "afternoon", "evening", "night" };
@@ -44,7 +44,7 @@ namespace Chronic
             if (match.Success && String.IsNullOrEmpty(token.Value) == false
                 && TokenIsAPeriodOfDay(nextToken) == false)
             {
-                return new Scalar(int.Parse(match.Groups[0].Value));
+                return new Scalar(decimal.Parse(match.Groups[0].Value));
             }
             return null;
         }
@@ -53,7 +53,7 @@ namespace Chronic
         {
             if (_dayPattern.IsMatch(token.Value))
             {
-                var value = int.Parse(token.Value);
+                var value = decimal.Parse(token.Value);
                 if (value <= 31 && TokenIsAPeriodOfDay(nextToken) == false)
                     return new ScalarDay(value);
             }
@@ -64,7 +64,7 @@ namespace Chronic
         {
             if (_monthPattern.IsMatch(token.Value))
             {
-                var value = int.Parse(token.Value);
+                var value = decimal.Parse(token.Value);
                 if (value <= 12 && TokenIsAPeriodOfDay(nextToken) == false)
                     return new ScalarMonth(value);
             }
@@ -75,7 +75,7 @@ namespace Chronic
         {
             if (_yearPattern.IsMatch(token.Value))
             {
-                var value = int.Parse(token.Value);
+                var value = decimal.Parse(token.Value);
                 if (TokenIsAPeriodOfDay(nextToken) == false)
                 {
                     if (value <= 37)

--- a/src/Chronic/Tags/Tag.cs
+++ b/src/Chronic/Tags/Tag.cs
@@ -27,7 +27,7 @@ namespace Chronic
 
         Span GetNextSpan(Pointer.Type pointer);
         Span GetCurrentSpan(Pointer.Type pointer);
-        Span GetOffset(Span span, int amount, Pointer.Type pointer);
+        Span GetOffset(Span span, decimal amount, Pointer.Type pointer);
     }
 
     public interface ITag

--- a/src/Chronic/Tokenizer.cs
+++ b/src/Chronic/Tokenizer.cs
@@ -49,7 +49,7 @@ namespace Chronic
             normalized = normalized
                 .ReplaceAll(@"\s+", " ")
                 .ReplaceAll(@"([/\-,@])", " " + "$1" + " ")
-                .ReplaceAll(@"['""\.,]", "")
+                .ReplaceAll(@"['"",]", "")
                 //.ReplaceAll(@"\bsecond (of|day|month|hour|minute|second)\b", "2nd $1")
                 .ReplaceAll(@"\b(1|one) second\b", "1 sec")
                 .ReplaceAll(@"\bthis second\b", "this sec")


### PR DESCRIPTION
This does intentionally change behavior where 15:20.50 is no longer 50 seconds, but instead 1/2 of a minute.  Old behavior can be enabled with: Chronic.Tags.Repeaters.RepeaterTime.OLD_TIME_DECIMAL_BEHAVIOR = true;